### PR TITLE
FIX: Bind to package, not recipe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "silverstripe/recipe-cms": "^1.0",
+    "silverstripe/cms": "^4.0",
     "guzzlehttp/guzzle": "~6.0"
   },
   "require-dev": {

--- a/src/forms/SlackSignupForm.php
+++ b/src/forms/SlackSignupForm.php
@@ -94,7 +94,7 @@ class SlackSignupForm extends Form
      * @param array $data
      * @param SlackSignupForm $form
      */
-    protected function submitSlackForm($data, $form)
+    public function submitSlackForm($data, $form)
     {
         $signup = SlackInvite::create();
         $form->saveInto($signup);


### PR DESCRIPTION
The recipe is one way of installing the CMS, but not the only way. This change also fixes situations where the silverstripe/recipe-cms ^4 has been installed, rather than ^1 (the numbering of which was a bug)